### PR TITLE
ISO 4217 check

### DIFF
--- a/src/Vendr.Contrib.PaymentProviders.Template/TemplatePaymentProvider.cs
+++ b/src/Vendr.Contrib.PaymentProviders.Template/TemplatePaymentProvider.cs
@@ -25,7 +25,7 @@ namespace Vendr.Contrib.PaymentProviders
             // Ensure currency has valid ISO 4217 code
             if (!Iso4217.CurrencyCodes.ContainsKey(currencyCode))
             {
-                throw new Exception("Currency must have a valid ISO 4217 currency code: " + currency.Name);
+                throw new Exception("Currency must be a valid ISO 4217 currency code: " + currency.Name);
             }
 
             return new PaymentFormResult()

--- a/src/Vendr.Contrib.PaymentProviders.Template/TemplatePaymentProvider.cs
+++ b/src/Vendr.Contrib.PaymentProviders.Template/TemplatePaymentProvider.cs
@@ -19,6 +19,15 @@ namespace Vendr.Contrib.PaymentProviders
 
         public override PaymentFormResult GenerateForm(OrderReadOnly order, string continueUrl, string cancelUrl, string callbackUrl, TemplateSettings settings)
         {
+            var currency = Vendr.Services.CurrencyService.GetCurrency(order.CurrencyId);
+            var currencyCode = currency.Code.ToUpperInvariant();
+
+            // Ensure currency has valid ISO 4217 code
+            if (!Iso4217.CurrencyCodes.ContainsKey(currencyCode))
+            {
+                throw new Exception("Currency must have a valid ISO 4217 currency code: " + currency.Name);
+            }
+
             return new PaymentFormResult()
             {
                 Form = new PaymentForm(continueUrl, FormMethod.Post)

--- a/src/Vendr.Contrib.PaymentProviders.Template/Vendr.Contrib.PaymentProviders.Template.csproj
+++ b/src/Vendr.Contrib.PaymentProviders.Template/Vendr.Contrib.PaymentProviders.Template.csproj
@@ -40,8 +40,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OD.Licensing, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OD.Licensing.0.1.0\lib\net45\OD.Licensing.dll</HintPath>
+    <Reference Include="OD.Licensing, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OD.Licensing.0.3.2\lib\net45\OD.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -73,11 +73,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vendr.Core, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Vendr.Core.0.1.0-alpha0336\lib\net472\Vendr.Core.dll</HintPath>
+    <Reference Include="Vendr.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vendr.Core.1.0.0\lib\net472\Vendr.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Vendr.Core.Web, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Vendr.Core.Web.0.1.0-alpha0336\lib\net472\Vendr.Core.Web.dll</HintPath>
+    <Reference Include="Vendr.Core.Web, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vendr.Core.Web.1.0.0\lib\net472\Vendr.Core.Web.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Vendr.Contrib.PaymentProviders.Template/packages.config
+++ b/src/Vendr.Contrib.PaymentProviders.Template/packages.config
@@ -5,8 +5,8 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
-  <package id="OD.Licensing" version="0.1.0" targetFramework="net472" />
+  <package id="OD.Licensing" version="0.3.2" targetFramework="net472" />
   <package id="Portable.BouncyCastle" version="1.8.5" targetFramework="net472" />
-  <package id="Vendr.Core" version="0.1.0-alpha0336" targetFramework="net472" />
-  <package id="Vendr.Core.Web" version="0.1.0-alpha0336" targetFramework="net472" />
+  <package id="Vendr.Core" version="1.0.0" targetFramework="net472" />
+  <package id="Vendr.Core.Web" version="1.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Added ISO 4217 check as default since most payment providers use this standard. In fact I haven't seen any payment providers which doesn't use this standard - if that is the case, it would probably be easier just to remove this instead of remember to add this check for all others.