### PR TITLE
Use stable Vendr version in payment provider template

### DIFF
--- a/src/Vendr.Contrib.PaymentProviders.Template/Vendr.Contrib.PaymentProviders.Template.csproj
+++ b/src/Vendr.Contrib.PaymentProviders.Template/Vendr.Contrib.PaymentProviders.Template.csproj
@@ -40,8 +40,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OD.Licensing, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OD.Licensing.0.1.0\lib\net45\OD.Licensing.dll</HintPath>
+    <Reference Include="OD.Licensing, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OD.Licensing.0.3.2\lib\net45\OD.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -73,11 +73,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vendr.Core, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Vendr.Core.0.1.0-alpha0336\lib\net472\Vendr.Core.dll</HintPath>
+    <Reference Include="Vendr.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vendr.Core.1.0.0\lib\net472\Vendr.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Vendr.Core.Web, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Vendr.Core.Web.0.1.0-alpha0336\lib\net472\Vendr.Core.Web.dll</HintPath>
+    <Reference Include="Vendr.Core.Web, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vendr.Core.Web.1.0.0\lib\net472\Vendr.Core.Web.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Vendr.Contrib.PaymentProviders.Template/packages.config
+++ b/src/Vendr.Contrib.PaymentProviders.Template/packages.config
@@ -5,8 +5,8 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
-  <package id="OD.Licensing" version="0.1.0" targetFramework="net472" />
+  <package id="OD.Licensing" version="0.3.2" targetFramework="net472" />
   <package id="Portable.BouncyCastle" version="1.8.5" targetFramework="net472" />
-  <package id="Vendr.Core" version="0.1.0-alpha0336" targetFramework="net472" />
-  <package id="Vendr.Core.Web" version="0.1.0-alpha0336" targetFramework="net472" />
+  <package id="Vendr.Core" version="1.0.0" targetFramework="net472" />
+  <package id="Vendr.Core.Web" version="1.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
I have updated the NuGet dependencies to use Vendr v1.0.0 as default, which is also required in NuGet package: https://github.com/vendrhub/vendr-payment-provider-template/blob/dev/build/NuSpecs/Vendr.Contrib.PaymentProviders.Template.nuspec#L19